### PR TITLE
[ENH] add shared function for dialogs

### DIFF
--- a/src/app/shared/functions/dialog.functions.ts
+++ b/src/app/shared/functions/dialog.functions.ts
@@ -1,0 +1,33 @@
+import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { Observable } from 'rxjs';
+import { Type } from '@angular/core';
+
+/**
+ * This function opens a new dialog box on the screen. It returns an `Observable` that lets us know when the dialog box is closed.
+ *
+ * @param dialog {MatDialog} - This is the thing that can open dialog boxes.
+ * @param dialogComponent {Type<T>} - This is what we want to show inside the dialog box.
+ * @param data {any} - This is the information we want to use in the dialog box.
+ *
+ * @returns An `Observable` that lets us know when the dialog box is closed.
+ */
+export function openDynamicDialog<T>(
+  dialog: MatDialog,
+  dialogComponent: Type<T>,
+  data: any
+): Observable<any> {
+  const config = new MatDialogConfig();
+
+  // setting the configuration for the dialog
+  config.height = '90%';
+  config.width = '90%';
+  config.maxHeight = '90vh';
+  config.maxWidth = '90vw';
+  config.disableClose = true;
+
+  // data object needed to render data within dialog template
+  config.data = data;
+
+  const dialogRef = dialog.open(dialogComponent, config);
+  return dialogRef.afterClosed();
+}


### PR DESCRIPTION
added new `functions` folder to contain useful methods that are **NOT** component specific. First of these methods is the `openDynamicDialog` method which will open a given dialog. This will further be used as new dialogs are created with specific use cases. 